### PR TITLE
fix(charts): s/hashValues/Object.hash/

### DIFF
--- a/charts_flutter/lib/src/behaviors/a11y/domain_a11y_explore_behavior.dart
+++ b/charts_flutter/lib/src/behaviors/a11y/domain_a11y_explore_behavior.dart
@@ -19,7 +19,6 @@ import 'package:charts_common/common.dart' as common
         DomainA11yExploreBehavior,
         VocalizationCallback,
         ExploreModeTrigger;
-import 'package:flutter/widgets.dart' show hashValues;
 import '../chart_behavior.dart' show ChartBehavior, GestureType;
 
 /// Behavior that generates semantic nodes for each domain.
@@ -110,7 +109,7 @@ class DomainA11yExploreBehavior<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(minimumWidth, vocalizationCallback, exploreModeTrigger,
+    return Object.hash(minimumWidth, vocalizationCallback, exploreModeTrigger,
         exploreModeEnabledAnnouncement, exploreModeDisabledAnnouncement);
   }
 }

--- a/charts_flutter/lib/src/behaviors/chart_title/chart_title.dart
+++ b/charts_flutter/lib/src/behaviors/chart_title/chart_title.dart
@@ -22,7 +22,6 @@ import 'package:charts_common/common.dart' as common
         MaxWidthStrategy,
         OutsideJustification,
         TextStyleSpec;
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 
 import '../chart_behavior.dart' show ChartBehavior, GestureType;
@@ -184,7 +183,7 @@ class ChartTitle<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
         behaviorPosition,
         layoutMinSize,
         layoutPreferredSize,

--- a/charts_flutter/lib/src/behaviors/legend/datum_legend.dart
+++ b/charts_flutter/lib/src/behaviors/legend/datum_legend.dart
@@ -26,7 +26,7 @@ import 'package:charts_common/common.dart' as common
         SelectionModelType,
         TextStyleSpec;
 import 'package:flutter/widgets.dart'
-    show BuildContext, EdgeInsets, Widget, hashValues;
+    show BuildContext, EdgeInsets, Widget;
 import 'package:meta/meta.dart' show immutable;
 import '../../chart_container.dart' show ChartContainerRenderObject;
 import '../chart_behavior.dart'
@@ -275,7 +275,7 @@ class DatumLegend<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
         selectionModelType,
         contentBuilder,
         position,

--- a/charts_flutter/lib/src/behaviors/legend/legend_content_builder.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_content_builder.dart
@@ -15,7 +15,7 @@
 
 import 'package:charts_common/common.dart' as common
     show Legend, LegendState, SeriesLegend;
-import 'package:flutter/widgets.dart' show BuildContext, hashValues, Widget;
+import 'package:flutter/widgets.dart' show BuildContext, Widget;
 import 'legend.dart';
 import 'legend_entry_layout.dart';
 import 'legend_layout.dart';
@@ -88,5 +88,5 @@ class TabularLegendContentBuilder extends BaseLegendContentBuilder {
   }
 
   @override
-  int get hashCode => hashValues(legendEntryLayout, legendLayout);
+  int get hashCode => Object.hash(legendEntryLayout, legendLayout);
 }

--- a/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
@@ -101,7 +101,7 @@ class TabularLegendLayout implements LegendLayout {
       cellPadding == o.cellPadding;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
       desiredMaxRows, desiredMaxColumns, isHorizontalFirst, cellPadding);
 
   Widget _buildHorizontalFirst(List<Widget> legendEntries) {

--- a/charts_flutter/lib/src/behaviors/legend/series_legend.dart
+++ b/charts_flutter/lib/src/behaviors/legend/series_legend.dart
@@ -28,7 +28,7 @@ import 'package:charts_common/common.dart' as common
         TextStyleSpec;
 import 'package:collection/collection.dart' show ListEquality;
 import 'package:flutter/widgets.dart'
-    show BuildContext, EdgeInsets, Widget, hashValues;
+    show BuildContext, EdgeInsets, Widget;
 import 'package:meta/meta.dart' show immutable;
 import '../../chart_container.dart' show ChartContainerRenderObject;
 import '../chart_behavior.dart'
@@ -288,7 +288,7 @@ class SeriesLegend<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
         selectionModelType,
         contentBuilder,
         position,

--- a/charts_flutter/lib/src/behaviors/line_point_highlighter.dart
+++ b/charts_flutter/lib/src/behaviors/line_point_highlighter.dart
@@ -21,7 +21,6 @@ import 'package:charts_common/common.dart' as common
         LinePointHighlighterFollowLineType,
         SelectionModelType,
         SymbolRenderer;
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 
 import 'chart_behavior.dart' show ChartBehavior, GestureType;
@@ -115,7 +114,7 @@ class LinePointHighlighter<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
+    return Object.hash(
       selectionModelType,
       defaultRadiusPx,
       radiusPaddingPx,

--- a/charts_flutter/lib/src/behaviors/range_annotation.dart
+++ b/charts_flutter/lib/src/behaviors/range_annotation.dart
@@ -25,7 +25,6 @@ import 'package:charts_common/common.dart' as common
         RangeAnnotation,
         TextStyleSpec;
 import 'package:collection/collection.dart' show ListEquality;
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 
 import 'chart_behavior.dart' show ChartBehavior, GestureType;
@@ -115,7 +114,7 @@ class RangeAnnotation<D> extends ChartBehavior<D> {
   }
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
       annotations,
       defaultColor,
       extendAxis,

--- a/charts_flutter/lib/src/behaviors/slider/slider.dart
+++ b/charts_flutter/lib/src/behaviors/slider/slider.dart
@@ -24,7 +24,6 @@ import 'package:charts_common/common.dart' as common
         SliderListenerCallback,
         SliderStyle,
         SymbolRenderer;
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 
 import '../chart_behavior.dart' show ChartBehavior, GestureType;
@@ -190,7 +189,7 @@ class Slider<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(eventTrigger, handleRenderer, initialDomainValue, roleId,
+    return Object.hash(eventTrigger, handleRenderer, initialDomainValue, roleId,
         snapToDatum, style, layoutPaintOrder);
   }
 }

--- a/charts_flutter/lib/src/text_style.dart
+++ b/charts_flutter/lib/src/text_style.dart
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:ui' show hashValues;
 import 'package:charts_common/common.dart' as common show Color, TextStyle;
 
 class TextStyle implements common.TextStyle {
@@ -31,5 +30,5 @@ class TextStyle implements common.TextStyle {
       lineHeight == other.lineHeight;
 
   @override
-  int get hashCode => hashValues(fontSize, fontFamily, color, lineHeight);
+  int get hashCode => Object.hash(fontSize, fontFamily, color, lineHeight);
 }


### PR DESCRIPTION
Dart:UI's `hashValues` has been deprecated and needed to be replaced with `Object.hash`.

This will block `betterment/mobile` from upgrading  Flutter (we're not upgrading to the new version(s) yet because there are issues with it, but let's get out ahead of it).

https://app.asana.com/0/1205839656626106/1209037231714503

/domain @Betterment/core-user-experience-mobile-eng 
/platform @Betterment/core-user-experience-mobile-eng 

/task https://app.asana.com/0/1205839656626106/1209037231714503